### PR TITLE
macOS instructions for Google Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,14 @@
 2. Open Violentmonkey dashboard.
 3. Install from URL - https://raw.githubusercontent.com/nelson-caberto/notifyMe/master/notifyMe.js
 4. Confirm Installation
+
+## macOS Users
+
+At the time of writing (June 2020), Google Chrome's browser notifications work intermittently with macOS Catalina.
+
+To ensure you receive browser notifications, you need to follow [these steps](https://crankwheel.zendesk.com/hc/en-us/articles/360009961499-macOS-Catalina-not-getting-desktop-notifications#:~:text=Search%20for%20%22Enable%20native%20notifications,than%20you%20are%20used%20to.):
+
+1. Open a new browser tab in Google Chrome
+2. Type in ```chrome://flags/``` and hit Enter
+3. Search for *"Enable native notifications"* and in the drop-down menu next to it, select *"Disabled"*. This will prompt you to restart Chrome. Go ahead and do so.
+4. Restart Chrome and now, you should get notifications on your desktop, although they will be in a slightly different style than you are used to.


### PR DESCRIPTION
Mac users need to take a few extra steps to ensure they see browser notifications in Google Chrome.